### PR TITLE
Event emitter deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+*swp
+*swo
+
 .idea
 coverage
 node_modules

--- a/index.js
+++ b/index.js
@@ -29,12 +29,17 @@ function unlistener(handler) {
  * a handler be added elsewhere.
  */
 module.exports = function endgame(handler) {
-    var undo;
+    var undo,
+        numberOfListeners;
 
     handler = handler || failsafe;
     undo = unlistener(handler);
 
-    if (!process.listenerCount(UNCAUGHT)) {
+    numberOfListeners = Object.prototype.hasOwnProperty.call(EventEmitter, 'listenerCount')
+        ? EventEmitter.listenerCount(process, UNCAUGHT)
+        : process.listenerCount(UNCAUGHT);
+
+    if (!numberOfListeners) {
         process.on(UNCAUGHT, handler);
         process.on(NEW, undo);
     }

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function endgame(handler) {
     handler = handler || failsafe;
     undo = unlistener(handler);
 
-    if (!EventEmitter.listenerCount(process, UNCAUGHT)) {
+    if (!process.listenerCount(UNCAUGHT)) {
         process.on(UNCAUGHT, handler);
         process.on(NEW, undo);
     }


### PR DESCRIPTION
Addressed the issue https://github.com/krakenjs/endgame/issues/5

Replaced the `EventEmitter.listenerCount` which has been deprecated since v4.0.0 with the `emitter.listenerCount` which has been added since v3.2.0

**Relevant Links**
https://nodejs.org/api/events.html#events_emitter_listenercount_eventname
https://nodejs.org/api/events.html#events_emitter_listenercount_eventname
